### PR TITLE
implement for &[T] and &mut [T]

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -2,7 +2,11 @@
 //! macros. Some are public so they can be accessed by the expanded macro code,
 //! but are not meant to be used by users directly and do not have a stable API.
 
-use core::{any::{TypeId, type_name}, marker::PhantomData, mem};
+use core::{
+    any::{type_name, TypeId},
+    marker::PhantomData,
+    mem,
+};
 
 /// A token struct used to capture the type of a value without taking ownership of
 /// it. Used to select a cast implementation in macros.
@@ -14,6 +18,44 @@ impl<T> CastToken<T> {
         Self(PhantomData)
     }
 }
+
+/// Supporting trait for autoderef specialization on references.
+pub trait TryCastSliceMut<'a, T: 'static> {
+    /// Attempt to cast a generic reference to a given type if the types are
+    /// equal.
+    ///
+    /// The reference does not have to be static as long as the reference target
+    /// type is static.
+    #[inline(always)]
+    fn try_cast<U: 'static>(&self, value: &'a mut [T]) -> Result<&'a mut [U], &'a mut [T]> {
+        if type_eq::<T, U>() {
+            Ok(unsafe { &mut *(value as *mut [T] as *mut [U]) })
+        } else {
+            Err(value)
+        }
+    }
+}
+
+impl<'a, T: 'static> TryCastSliceMut<'a, T> for &&&&CastToken<&'a mut [T]> {}
+
+/// Supporting trait for autoderef specialization on references.
+pub trait TryCastSliceRef<'a, T: 'static> {
+    /// Attempt to cast a generic reference to a given type if the types are
+    /// equal.
+    ///
+    /// The reference does not have to be static as long as the reference target
+    /// type is static.
+    #[inline(always)]
+    fn try_cast<U: 'static>(&self, value: &'a [T]) -> Result<&'a [U], &'a [T]> {
+        if type_eq::<T, U>() {
+            Ok(unsafe { &*(value as *const [T] as *const [U]) })
+        } else {
+            Err(value)
+        }
+    }
+}
+
+impl<'a, T: 'static> TryCastSliceRef<'a, T> for &&&CastToken<&'a [T]> {}
 
 /// Supporting trait for autoderef specialization on mutable references.
 pub trait TryCastMut<'a, T: 'static> {


### PR DESCRIPTION
Implementing for references over arbitrary unsized types doesn't work because it may not be safe to cast between them (I think?). But it's definitely safe to do this for [T].

This makes it possible to perform casts like `cast!(some_slice, &[u8])` (useful for optimizing for byte arrays).