### PR TITLE
Implement lifetime-free ref and mut casts for unsized type

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -48,7 +48,7 @@ pub trait TryCastMutLifetimeFree<'a, T: ?Sized, U: LifetimeFree + ?Sized> {
     }
 }
 
-impl<'a, T, U: LifetimeFree> TryCastMutLifetimeFree<'a, T, U>
+impl<'a, T: ?Sized, U: LifetimeFree + ?Sized> TryCastMutLifetimeFree<'a, T, U>
     for &&&&&&&(CastToken<&'a mut T>, CastToken<&'a mut U>)
 {
 }
@@ -72,7 +72,7 @@ pub trait TryCastRefLifetimeFree<'a, T: ?Sized, U: LifetimeFree + ?Sized> {
     }
 }
 
-impl<'a, T, U: LifetimeFree> TryCastRefLifetimeFree<'a, T, U>
+impl<'a, T: ?Sized, U: LifetimeFree + ?Sized> TryCastRefLifetimeFree<'a, T, U>
     for &&&&&&(CastToken<&'a T>, CastToken<&'a U>)
 {
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -353,6 +353,30 @@ mod tests {
         }));
     }
 
+    #[test]
+    fn cast_lifetime_free_unsized_ref() {
+        fn can_cast<T>(value: &[T]) -> bool {
+            cast!(value, &[u8]).is_ok()
+        }
+
+        let value = 42i32;
+        assert!(can_cast(&[1_u8, 2, 3, 4]));
+        assert!(!can_cast(&[1_i8, 2, 3, 4]));
+        assert!(!can_cast(&[&value, &value]));
+    }
+
+    #[test]
+    fn cast_lifetime_free_unsized_mut() {
+        fn can_cast<T>(value: &mut [T]) -> bool {
+            cast!(value, &mut [u8]).is_ok()
+        }
+
+        let value = 42i32;
+        assert!(can_cast(&mut [1_u8, 2, 3, 4]));
+        assert!(!can_cast(&mut [1_i8, 2, 3, 4]));
+        assert!(!can_cast(&mut [&value, &value]));
+    }
+
     macro_rules! test_lifetime_free_cast {
         () => {};
 


### PR DESCRIPTION
The `TryCastMutLifetimeFree` and `TryCastRefLifetimeFree` trait implementations have default `Sized` bound on the `T` and `U` generics, which prevents unsized types not defined as static from casiting.

This PR adds `?Sized` bound to `T` and `U` generics in `TryCastMutLifetimeFree` and `TryCastRefLifetimeFree` trait implementation.

For example this makes it possible to specialize slices without restricting the source slice item type to be static:
```rust
fn func<T>(slice: &[T]) {
    if let Ok(byte_slice) = cast!(slice, &[u8]) {
        // specialized impl...
    } else {
        // default impl...
    }
}
```