### PR TITLE
Fix miscompilation in `transmute_unchecked` introduced by bug in LLVM

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -512,5 +512,15 @@ mod tests {
             0u8 => Err(0u8),
             Some(42u8) => Ok(Some(42u8)),
         }
+
+        // See https://github.com/rust-lang/rust/issues/127286 for details.
+        for (u8, u8) as TupleU8U8 {
+            (1u8, 2u8) => Ok((1u8, 2u8)),
+            1u8 => Err(1u8),
+        }
+        for (bool, u16) as TupleBoolU16 {
+            (false, 2u16) => Ok((false, 2u16)),
+            true => Err(true),
+        }
     }
 }


### PR DESCRIPTION
Currently some casts from byte primitives to two element tuple lead to miscompilation on **release** builds on Rust `>=1.70.0`:
- `castaway::cast!(123_u8, (u8, u8))` unexpectedly returns `Ok(...)` that leads to **UB**.
- `castaway::cast!(false, (bool, u16))` leads to `SIGILL: illegal instruction` runtime error.

Upstream issues:
- Rust: https://github.com/rust-lang/rust/issues/127286
- LLVM: https://github.com/llvm/llvm-project/issues/97702

I suggest considering adding a safe "workaround" to fix the issue in this crate without having to wait for the upstream fixes. This way we will have this fixed in older Rust versions as well.

This PR adds size eq `assert` to `transmute_unchecked`. This workaround was found while preparing an MRE for an upstream issue.

Checked locally with `cargo test --release` for Rust `1.38`, `1.68.0`, `1.69.0`, `1.70.0`, `1.71.0`, `1.72.0`, `stable`, `beta`, `nightly`. Generated assembly for other tests cases for the release build seems the same (checks and casts are optimized away).

Btw: it might also be a good idea to run tests in `--release` mode as well since the crate relies heavily on optimizing the casts to zero-cost.