### PR TITLE
Update CI config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,4 +8,5 @@ jobs:
   test:
     uses: sagebind/workflows/.github/workflows/rust-ci.yml@v1
     with:
-      msrv: "1.38"
+      msrv: "1.54"
+      test-release: true


### PR DESCRIPTION
Now that the macOS 11 runner is gone, there's simply no way to test Rust versions older than 1.54 in GitHub Actions any more.

Also run tests in release mode to ensure that optimizations don't break any logic or compilation.